### PR TITLE
fix: add ecr create repository action

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ data "aws_iam_policy_document" "cicd_ecr" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
+      "ecr:CreateRepository",
       "ecr:DescribeImages",
       "ecr:DescribeRepositories",
       "ecr:GetAuthorizationToken",


### PR DESCRIPTION
this has been missing this whole time, never noticed because we haven't
created a new image in months. oop